### PR TITLE
publish-to-pypi action  macos 13 update. 

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -119,7 +119,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
+          - runner: macos-14
             target: x86_64
           - runner: macos-14
             target: aarch64


### PR DESCRIPTION
Swapping MACOS-13 to MACOS-14 since it will be retire in september