### PR TITLE
bugfix: Adding binaries to paths for testing.

### DIFF
--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -41,6 +41,17 @@ jobs:
         with:
           save-if: ${{ github.ref_name == 'main' }}
 
+      - name: Build CLI binary
+        run: cargo build --release -p cli-rusty-ssim
+
+      - name: Add binary to PATH (Unix)
+        if: runner.os != 'Windows'
+        run: echo "${{ github.workspace }}/target/release" >> $GITHUB_PATH
+
+      - name: Add binary to PATH (Windows)
+        if: runner.os == 'Windows'
+        run: echo "${{ github.workspace }}\target\release" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Run tests
         if: github.ref_name != 'main'
         run: >

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -41,6 +41,12 @@ jobs:
         with:
           save-if: ${{ github.ref_name == 'main' }}
 
+      - name: Build CLI binary
+        run: cargo build -p cli-rusty-ssim
+
+      - name: Add binary to PATH (Windows)
+        run: echo "${{ github.workspace }}\\target\debug" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Run tests
         if: github.ref_name != 'main'
         run: >
@@ -63,6 +69,12 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref_name == 'main' }}
+
+      - name: Build CLI binary
+        run: cargo build -p cli-rusty-ssim
+
+      - name: Add binary to PATH (Unix)
+        run: echo "${{ github.workspace }}/target/debug" >> $GITHUB_PATH
 
       - name: Run tests
         if: github.ref_name != 'main'

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -23,12 +23,12 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  test:
+  windows:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ windows-latest ]
 
     steps:
       - uses: actions/checkout@v4
@@ -41,19 +41,30 @@ jobs:
         with:
           save-if: ${{ github.ref_name == 'main' }}
 
-      - name: Build CLI binary
-        run: cargo build --release -p cli-rusty-ssim
-
-      - name: Add binary to PATH (Unix)
-        if: runner.os != 'Windows'
-        run: echo "${{ github.workspace }}/target/release" >> $GITHUB_PATH
-
-      - name: Add binary to PATH (Windows)
-        if: runner.os == 'Windows'
-        run: echo "${{ github.workspace }}\target\release" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
       - name: Run tests
         if: github.ref_name != 'main'
         run: >
           cargo test -p cli-rusty-ssim --test cli_tests
 
+  linux:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        run: rustup show
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref_name == 'main' }}
+
+      - name: Run tests
+        if: github.ref_name != 'main'
+        run: >
+          cargo test -p cli-rusty-ssim --test cli_tests

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -1,4 +1,7 @@
 name: Test CLI
+permissions:
+  contents: read
+  pull-requests: read
 
 on:
   pull_request:


### PR DESCRIPTION
Github action workflow for CLI is error out on Linux due to the binary path.  This update will build the binaries and add them to the path. 