### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -1,4 +1,6 @@
 name: Test Rust
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/wcagreen/rusty-ssim/security/code-scanning/3](https://github.com/wcagreen/rusty-ssim/security/code-scanning/3)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since this workflow only checks out code and runs tests, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the workflow to check out the repository code. The best place to add this is at the top level of the workflow file (after the `name` field), so it applies to all jobs unless overridden. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
