### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,4 +1,6 @@
 name: test-python.yml
+permissions:
+  contents: read
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/wcagreen/rusty-ssim/security/code-scanning/2](https://github.com/wcagreen/rusty-ssim/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs tests, it only needs read access to repository contents. The best way to do this is to add the following at the top level of the workflow file (after the `name:` and before `on:`), or at the job level if only specific jobs need the restriction. In this case, adding it at the workflow level ensures all jobs inherit the restriction. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
