### PR TITLE
CLI Publisher error out due to path issues.

### DIFF
--- a/.github/workflows/publish-cli-to-packages.yml
+++ b/.github/workflows/publish-cli-to-packages.yml
@@ -15,22 +15,28 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            name: ssim-linux-x64
+            name: cli-rusty-ssim-linux-x64
+            binary: cli-rusty-ssim
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            name: ssim-linux-x64-musl
+            name: cli-rusty-ssim-linux-x64-musl
+            binary: cli-rusty-ssim
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            name: ssim-linux-arm64
+            name: cli-rusty-ssim-linux-arm64
+            binary: cli-rusty-ssim
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            name: ssim-windows-x64.exe
+            name: cli-rusty-ssim-windows-x64
+            binary: cli-rusty-ssim.exe
           - target: x86_64-apple-darwin
             os: macos-latest
-            name: ssim-macos-x64
+            name: cli-rusty-ssim-macos-x64
+            binary: cli-rusty-ssim
           - target: aarch64-apple-darwin
             os: macos-latest
-            name: ssim-macos-arm64
+            name: cli-rusty-ssim-macos-arm64
+            binary: cli-rusty-ssim
 
     runs-on: ${{ matrix.os }}
 
@@ -63,11 +69,23 @@ jobs:
         env:
           RUSTFLAGS: -C target-feature=+crt-static
 
+      - name: Verify binary exists
+        run: |
+          echo "Contents of target/${{ matrix.target }}/release:"
+          ls -la target/${{ matrix.target }}/release/
+          echo "Looking for binary: ${{ matrix.binary }}"
+          if [ -f "target/${{ matrix.target }}/release/${{ matrix.binary }}" ]; then
+            echo "Binary found!"
+          else
+            echo "Binary not found!"
+            exit 1
+          fi
+
       - name: Package binary (Unix)
         if: matrix.os != 'windows-latest'
         run: |
           cd target/${{ matrix.target }}/release
-          tar -czf ${{ matrix.name }}.tar.gz ssim
+          tar -czf ${{ matrix.name }}.tar.gz ${{ matrix.binary }}
           echo "ASSET_PATH=target/${{ matrix.target }}/release/${{ matrix.name }}.tar.gz" >> $GITHUB_ENV
           echo "ASSET_NAME=${{ matrix.name }}.tar.gz" >> $GITHUB_ENV
 
@@ -75,7 +93,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           cd target/${{ matrix.target }}/release
-          7z a ${{ matrix.name }}.zip ssim.exe
+          7z a ${{ matrix.name }}.zip ${{ matrix.binary }}
           echo "ASSET_PATH=target/${{ matrix.target }}/release/${{ matrix.name }}.zip" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "ASSET_NAME=${{ matrix.name }}.zip" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
@@ -121,27 +139,27 @@ jobs:
             
             Choose the appropriate binary for your system:
             
-            - **Linux (x64)**: `ssim-linux-x64.tar.gz`
-            - **Linux (ARM64)**: `ssim-linux-arm64.tar.gz` 
-            - **Linux (musl)**: `ssim-linux-x64-musl.tar.gz`
-            - **macOS (Intel)**: `ssim-macos-x64.tar.gz`
-            - **macOS (Apple Silicon)**: `ssim-macos-arm64.tar.gz`
-            - **Windows**: `ssim-windows-x64.exe.zip`
+            - **Linux (x64)**: `cli-rusty-ssim-linux-x64.tar.gz`
+            - **Linux (ARM64)**: `cli-rusty-ssim-linux-arm64.tar.gz` 
+            - **Linux (musl)**: `cli-rusty-ssim-linux-x64-musl.tar.gz`
+            - **macOS (Intel)**: `cli-rusty-ssim-macos-x64.tar.gz`
+            - **macOS (Apple Silicon)**: `cli-rusty-ssim-macos-arm64.tar.gz`
+            - **Windows**: `cli-rusty-ssim-windows-x64.zip`
             
             ### Installation
             
             **Linux/macOS:**
             ```bash
             # Download and extract
-            curl -L https://github.com/wcagreen/rusty-ssim/releases/download/${{ github.ref_name }}/ssim-linux-x64.tar.gz | tar xz
+            curl -L https://github.com/wcagreen/rusty-ssim/releases/download/${{ github.ref_name }}/cli-rusty-ssim-linux-x64.tar.gz | tar xz
             
             # Make executable and move to PATH
-            chmod +x ssim
-            sudo mv ssim /usr/local/bin/
+            chmod +x cli-rusty-ssim
+            sudo mv cli-rusty-ssim /usr/local/bin/
             ```
             
             **Windows:**
-            1. Download `ssim-windows-x64.exe.zip`
+            1. Download `cli-rusty-ssim-windows-x64.zip`
             2. Extract the `cli-rusty-ssim.exe` file
             3. Add the directory to your PATH or run directly
             
@@ -152,7 +170,7 @@ jobs:
             ssim csv --ssim-path input.ssim --output-path output.csv
             
             # Convert SSIM to Parquet with compression
-            ssim parquet --ssim-path input.ssim --output-path ./output/ --compression snappy
+            ssim  parquet --ssim-path input.ssim --output-path ./output/ --compression snappy
             
             # View help
             ssim --help

--- a/.github/workflows/publish-cli-to-packages.yml
+++ b/.github/workflows/publish-cli-to-packages.yml
@@ -69,18 +69,6 @@ jobs:
         env:
           RUSTFLAGS: -C target-feature=+crt-static
 
-      - name: Verify binary exists
-        run: |
-          echo "Contents of target/${{ matrix.target }}/release:"
-          ls -la target/${{ matrix.target }}/release/
-          echo "Looking for binary: ${{ matrix.binary }}"
-          if [ -f "target/${{ matrix.target }}/release/${{ matrix.binary }}" ]; then
-            echo "Binary found!"
-          else
-            echo "Binary not found!"
-            exit 1
-          fi
-
       - name: Package binary (Unix)
         if: matrix.os != 'windows-latest'
         run: |

--- a/.github/workflows/publish-cli-to-packages.yml
+++ b/.github/workflows/publish-cli-to-packages.yml
@@ -16,15 +16,15 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             name: cli-rusty-ssim-linux-x64
-            binary: cli-rusty-ssim
+            binary: cli-rusty-ssim.exe
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             name: cli-rusty-ssim-linux-x64-musl
-            binary: cli-rusty-ssim
+            binary: cli-rusty-ssim.exe
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             name: cli-rusty-ssim-linux-arm64
-            binary: cli-rusty-ssim
+            binary: cli-rusty-ssim.exe
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             name: cli-rusty-ssim-windows-x64
@@ -32,11 +32,11 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-latest
             name: cli-rusty-ssim-macos-x64
-            binary: cli-rusty-ssim
+            binary: cli-rusty-ssim.exe
           - target: aarch64-apple-darwin
             os: macos-latest
             name: cli-rusty-ssim-macos-arm64
-            binary: cli-rusty-ssim
+            binary: cli-rusty-ssim.exe
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Adding binary name, as well as fixing the binary path since it's cli-rusty-ssim and not ssim. 